### PR TITLE
Added rules: mask emails, organizational units, root units

### DIFF
--- a/src/contents/index.ts
+++ b/src/contents/index.ts
@@ -20,7 +20,10 @@ export const annotatePatterns = {
   ],
   accountId: ["\\d{12}", "\\d{4}-\\d{4}-\\d{4}"],
   accessKeyId: ["(?:ASIA|AKIA|AROA|AIDA)([A-Z0-7]{16})"],
-  secretAccessKey: ["[a-zA-Z0-9+/]{40}"]
+  secretAccessKey: ["[a-zA-Z0-9+/]{40}"],
+  organizationalUnit: ["ou-[a-zA-Z0-9-]{4,32}"],
+  rootUnit: ["r-[a-zA-Z0-9]{4,32}"],
+  email: ["[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}"]
 } as const;
 
 chrome.runtime.sendMessage({ method: "GET_SETTINGS" }, (settings: Settings) => {
@@ -45,6 +48,12 @@ const _applySettings = (settings: Settings) => {
     settings.maskAccessKeyIds.toString();
   document.body.dataset.aws_masking_secret_access_keys =
     settings.maskSecretAccessKeys.toString();
+  document.body.dataset.aws_masking_organizational_units =
+    settings.maskOrganizationalUnits.toString();
+  document.body.dataset.aws_masking_root_units =
+    settings.maskRootUnits.toString();
+  document.body.dataset.aws_masking_emails =
+    settings.maskEmails.toString();
 };
 
 let observer: MutationObserver;
@@ -81,7 +90,10 @@ const _annotateTexts = (node: Element) => {
       aws_masking_arn: annotatePatterns.arn,
       aws_masking_account_id: annotatePatterns.accountId,
       aws_masking_access_key_id: annotatePatterns.accessKeyId,
-      aws_masking_secret_access_key: annotatePatterns.secretAccessKey
+      aws_masking_secret_access_key: annotatePatterns.secretAccessKey,
+      aws_masking_organizational_unit: annotatePatterns.organizationalUnit,
+      aws_masking_root_unit: annotatePatterns.rootUnit,
+      aws_masking_email: annotatePatterns.email
     };
 
     if (node.parentElement.dataset.aws_masking_arn === "true")
@@ -92,6 +104,12 @@ const _annotateTexts = (node: Element) => {
       delete mappings.aws_masking_access_key_id;
     if (node.parentElement.dataset.aws_masking_secret_access_key === "true")
       delete mappings.aws_masking_secret_access_key;
+    if (node.parentElement.dataset.aws_masking_organizational_unit === "true")
+      delete mappings.aws_masking_organizational_unit;
+    if (node.parentElement.dataset.aws_masking_root_unit === "true")
+      delete mappings.aws_masking_root_unit;
+    if (node.parentElement.dataset.aws_masking_email === "true")
+      delete mappings.aws_masking_email;
 
     const nodeVal = node.nodeValue;
     const newElement = document.createElement("span");
@@ -140,7 +158,10 @@ const _annotateInput = (input: HTMLInputElement) => {
     aws_masking_arn: annotatePatterns.arn,
     aws_masking_account_id: annotatePatterns.accountId,
     aws_masking_access_key_id: annotatePatterns.accessKeyId,
-    aws_masking_secret_access_key: annotatePatterns.secretAccessKey
+    aws_masking_secret_access_key: annotatePatterns.secretAccessKey,
+    aws_masking_organizational_unit: annotatePatterns.organizationalUnit,
+    aws_masking_root_unit: annotatePatterns.rootUnit,
+    aws_masking_email: annotatePatterns.email
   };
 
   for (const [dataAttr, patterns] of Object.entries(mappings)) {

--- a/src/contents/styles.css
+++ b/src/contents/styles.css
@@ -117,5 +117,64 @@ body {
         }
       }
     }
+
+    /* organizational unit */
+    &[data-aws_masking_organizational_units="true"] {
+      span[data-aws_masking_organizational_unit="true"] {
+        filter: blur(5px);
+      }
+
+      &.awsui-polaris-dark-mode[data-aws_masking_inputs="true"],
+      &[data-aws_masking_inputs="true"] {
+        textarea,
+        input[type="text"],
+        input[type="search"] {
+          &[data-aws_masking_organizational_unit="true"] {
+            color: transparent !important;
+            text-shadow: 0px 0px 8px rgba(255, 255, 255, 0.8) !important;
+          }
+        }
+      }
+    }
+
+    /* root unit */
+    &[data-aws_masking_root_units="true"] {
+      span[data-aws_masking_root_unit="true"] {
+        filter: blur(5px);
+      }
+
+      &.awsui-polaris-dark-mode[data-aws_masking_inputs="true"],
+      &[data-aws_masking_inputs="true"] {
+        textarea,
+        input[type="text"],
+        input[type="search"] {
+          &[data-aws_masking_root_unit="true"] {
+            color: transparent !important;
+            text-shadow: 0px 0px 8px rgba(255, 255, 255, 0.8) !important;
+          }
+        }
+      }
+    }
+
+    /* email */
+    &[data-aws_masking_emails="true"] {
+      span[data-aws_masking_email="true"] {
+        filter: blur(5px);
+      }
+
+      &.awsui-polaris-dark-mode[data-aws_masking_inputs="true"],
+      &[data-aws_masking_inputs="true"] {
+        textarea,
+        input[type="text"],
+        input[type="search"] {
+          &[data-aws_masking_email="true"] {
+            color: transparent !important;
+            text-shadow: 0px 0px 8px rgba(255, 255, 255, 0.8) !important;
+          }
+        }
+      }
+    }
+
+    /* Remove the phone number styles */
   }
 }

--- a/src/contents/styles.css
+++ b/src/contents/styles.css
@@ -1,180 +1,49 @@
 /* TODO: refactor */
 
-body {
-  &:not([data-aws_masking_disabled="true"]) {
-    /* account id */
-    &[data-aws_masking_account_ids="true"] {
-      span[data-aws_masking_account_id="true"] {
-        filter: blur(5px);
-      }
+body:not([data-aws_masking_disabled="true"]) {
+  /* Common styles for all masked elements */
+  [data-aws_masking_account_id="true"],
+  [data-aws_masking_arn="true"],
+  [data-aws_masking_access_key_id="true"],
+  [data-aws_masking_secret_access_key="true"],
+  [data-aws_masking_organizational_unit="true"],
+  [data-aws_masking_root_unit="true"],
+  [data-aws_masking_email="true"] {
+    filter: blur(5px);
+  }
 
-      &.awsui-polaris-dark-mode[data-aws_masking_inputs="true"] {
-        textarea,
-        input[type="text"],
-        input[type="search"] {
-          &[data-aws_masking_account_id="true"] {
-            color: transparent !important;
-            text-shadow: 0px 0px 8px rgba(255, 255, 255, 0.8) !important;
-          }
-        }
-      }
-
-      &[data-aws_masking_inputs="true"] {
-        textarea,
-        input[type="text"],
-        input[type="search"] {
-          &[data-aws_masking_account_id="true"] {
-            color: transparent !important;
-            text-shadow: 0px 0px 8px rgba(0, 0, 0, 0.5) !important;
-          }
-        }
+  /* Common styles for masked inputs */
+  &[data-aws_masking_inputs="true"] {
+    textarea,
+    input[type="text"],
+    input[type="search"] {
+      &[data-aws_masking_account_id="true"],
+      &[data-aws_masking_arn="true"],
+      &[data-aws_masking_access_key_id="true"],
+      &[data-aws_masking_secret_access_key="true"],
+      &[data-aws_masking_organizational_unit="true"],
+      &[data-aws_masking_root_unit="true"],
+      &[data-aws_masking_email="true"] {
+        color: transparent !important;
+        text-shadow: 0px 0px 8px rgba(0, 0, 0, 0.5) !important;
       }
     }
+  }
 
-    /* arn */
-    &[data-aws_masking_arns="true"] {
-      span[data-aws_masking_arn="true"] {
-        filter: blur(5px);
-      }
-
-      &.awsui-polaris-dark-mode[data-aws_masking_inputs="true"] {
-        textarea,
-        input[type="text"],
-        input[type="search"] {
-          &[data-aws_masking_arn="true"] {
-            color: transparent !important;
-            text-shadow: 0px 0px 8px rgba(255, 255, 255, 0.8) !important;
-          }
-        }
-      }
-
-      &[data-aws_masking_inputs="true"] {
-        textarea,
-        input[type="text"],
-        input[type="search"] {
-          &[data-aws_masking_arn="true"] {
-            color: transparent !important;
-            text-shadow: 0px 0px 8px rgba(0, 0, 0, 0.5) !important;
-          }
-        }
+  /* Dark mode specific styles */
+  &.awsui-polaris-dark-mode[data-aws_masking_inputs="true"] {
+    textarea,
+    input[type="text"],
+    input[type="search"] {
+      &[data-aws_masking_account_id="true"],
+      &[data-aws_masking_arn="true"],
+      &[data-aws_masking_access_key_id="true"],
+      &[data-aws_masking_secret_access_key="true"],
+      &[data-aws_masking_organizational_unit="true"],
+      &[data-aws_masking_root_unit="true"],
+      &[data-aws_masking_email="true"] {
+        text-shadow: 0px 0px 8px rgba(255, 255, 255, 0.8) !important;
       }
     }
-
-    /* access key id */
-    &[data-aws_masking_access_key_ids="true"] {
-      span[data-aws_masking_access_key_id="true"] {
-        filter: blur(5px);
-      }
-
-      &.awsui-polaris-dark-mode[data-aws_masking_inputs="true"] {
-        textarea,
-        input[type="text"],
-        input[type="search"] {
-          &[data-aws_masking_access_key_id="true"] {
-            color: transparent !important;
-            text-shadow: 0px 0px 8px rgba(255, 255, 255, 0.8) !important;
-          }
-        }
-      }
-
-      &[data-aws_masking_inputs="true"] {
-        textarea,
-        input[type="text"],
-        input[type="search"] {
-          &[data-aws_masking_access_key_id="true"] {
-            color: transparent !important;
-            text-shadow: 0px 0px 8px rgba(0, 0, 0, 0.5) !important;
-          }
-        }
-      }
-    }
-
-    /* secret access key */
-    &[data-aws_masking_secret_access_keys="true"] {
-      span[data-aws_masking_secret_access_key="true"] {
-        filter: blur(5px);
-      }
-
-      &.awsui-polaris-dark-mode[data-aws_masking_inputs="true"] {
-        textarea,
-        input[type="text"],
-        input[type="search"] {
-          &[data-aws_masking_secret_access_key="true"] {
-            color: transparent !important;
-            text-shadow: 0px 0px 8px rgba(255, 255, 255, 0.8) !important;
-          }
-        }
-      }
-
-      &[data-aws_masking_inputs="true"] {
-        textarea,
-        input[type="text"],
-        input[type="search"] {
-          &[data-aws_masking_secret_access_key="true"] {
-            color: transparent !important;
-            text-shadow: 0px 0px 8px rgba(0, 0, 0, 0.5) !important;
-          }
-        }
-      }
-    }
-
-    /* organizational unit */
-    &[data-aws_masking_organizational_units="true"] {
-      span[data-aws_masking_organizational_unit="true"] {
-        filter: blur(5px);
-      }
-
-      &.awsui-polaris-dark-mode[data-aws_masking_inputs="true"],
-      &[data-aws_masking_inputs="true"] {
-        textarea,
-        input[type="text"],
-        input[type="search"] {
-          &[data-aws_masking_organizational_unit="true"] {
-            color: transparent !important;
-            text-shadow: 0px 0px 8px rgba(255, 255, 255, 0.8) !important;
-          }
-        }
-      }
-    }
-
-    /* root unit */
-    &[data-aws_masking_root_units="true"] {
-      span[data-aws_masking_root_unit="true"] {
-        filter: blur(5px);
-      }
-
-      &.awsui-polaris-dark-mode[data-aws_masking_inputs="true"],
-      &[data-aws_masking_inputs="true"] {
-        textarea,
-        input[type="text"],
-        input[type="search"] {
-          &[data-aws_masking_root_unit="true"] {
-            color: transparent !important;
-            text-shadow: 0px 0px 8px rgba(255, 255, 255, 0.8) !important;
-          }
-        }
-      }
-    }
-
-    /* email */
-    &[data-aws_masking_emails="true"] {
-      span[data-aws_masking_email="true"] {
-        filter: blur(5px);
-      }
-
-      &.awsui-polaris-dark-mode[data-aws_masking_inputs="true"],
-      &[data-aws_masking_inputs="true"] {
-        textarea,
-        input[type="text"],
-        input[type="search"] {
-          &[data-aws_masking_email="true"] {
-            color: transparent !important;
-            text-shadow: 0px 0px 8px rgba(255, 255, 255, 0.8) !important;
-          }
-        }
-      }
-    }
-
-    /* Remove the phone number styles */
   }
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -5,6 +5,9 @@ export type Settings = {
   maskArns: boolean;
   maskAccessKeyIds: boolean;
   maskSecretAccessKeys: boolean;
+  maskOrganizationalUnits: boolean;
+  maskRootUnits: boolean;
+  maskEmails: boolean;
 };
 
 export const defaultSettings: Settings = {
@@ -13,5 +16,8 @@ export const defaultSettings: Settings = {
   maskAccountIds: true,
   maskArns: true,
   maskAccessKeyIds: true,
-  maskSecretAccessKeys: true
+  maskSecretAccessKeys: true,
+  maskOrganizationalUnits: true,
+  maskRootUnits: true,
+  maskEmails: true
 };

--- a/src/popup/index.tsx
+++ b/src/popup/index.tsx
@@ -60,6 +60,32 @@ function IndexPopup() {
     }));
   }, []);
 
+  const handleChangeMaskOrganizationalUnits = useCallback((checked: boolean) => {
+    setSettings((prev) => ({
+      ...defaultSettings,
+      ...prev,
+      maskOrganizationalUnits: checked
+    }));
+  }, []);
+
+  const handleChangeMaskRootUnits = useCallback((checked: boolean) => {
+    setSettings((prev) => ({
+      ...defaultSettings,
+      ...prev,
+      maskRootUnits: checked
+    }));
+  }, []);
+
+  const handleChangeMaskEmails = useCallback((checked: boolean) => {
+    setSettings((prev) => ({
+      ...defaultSettings,
+      ...prev,
+      maskEmails: checked
+    }));
+  }, []);
+
+  // Remove the handleChangeMaskPhoneNumbers function
+
   return (
     <div className="bg-secondary text-white">
       <div className="px-4 py-2 flex items-center gap-2">
@@ -98,6 +124,21 @@ function IndexPopup() {
           label="Mask Secret Access Keys"
           checked={settings.maskSecretAccessKeys}
           onChange={handleChangeMaskSecretAccessKeys}
+        />
+        <Switch
+          label="Mask Organizational Units"
+          checked={settings.maskOrganizationalUnits}
+          onChange={handleChangeMaskOrganizationalUnits}
+        />
+        <Switch
+          label="Mask Root Units"
+          checked={settings.maskRootUnits}
+          onChange={handleChangeMaskRootUnits}
+        />
+        <Switch
+          label="Mask Emails"
+          checked={settings.maskEmails}
+          onChange={handleChangeMaskEmails}
         />
       </div>
     </div>


### PR DESCRIPTION
Nice extension! 

I've been recording some videos with aws organizations and IAM identity center and feel bad every time I let me email or organization units go on screen.

<img width="1721" alt="aws-masked-pr" src="https://github.com/user-attachments/assets/1672ade6-ae91-4712-9bad-e77e829edbbb">
